### PR TITLE
Cache release asset reads to stop burning the GitHub API rate limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ node_modules
 docs/_book/
 
 /env.sh
+.claude/

--- a/lib/backends/backend.js
+++ b/lib/backends/backend.js
@@ -65,14 +65,15 @@ export class Backend {
   // Caching the promise also coalesces concurrent requests for the same asset.
   async readAsset(asset) {
     const key = String(asset.id);
-    if (!this.#assetMemos[key]) {
-      this.#assetMemos[key] = this.readAssetFresh(asset).catch((err) => {
+    const memo = this.#assetMemos;
+    if (!memo[key]) {
+      memo[key] = this.readAssetFresh(asset).catch((err) => {
         // never cache failures, e.g. a rate limited backend
-        delete this.#assetMemos[key];
+        delete memo[key];
         throw err;
       });
     }
-    return this.#assetMemos[key];
+    return memo[key];
   }
 
   // Return the full content of an asset

--- a/lib/backends/backend.js
+++ b/lib/backends/backend.js
@@ -9,6 +9,7 @@ import streamRes from "stream-res";
 const streamResAsync = util.promisify(streamRes);
 
 export class Backend {
+  #assetMemos = {};
   constructor(pecans, opts = {}) {
     const defaults = {
       // Folder to cache assets
@@ -31,6 +32,7 @@ export class Backend {
   // New release? clear cache
   onRelease() {
     this.cacheId++;
+    this.#assetMemos = {};
   }
   // Initialize the backend
   async init() {
@@ -58,8 +60,23 @@ export class Backend {
     throw Error("Abstract Method");
   }
 
-  // Return stream for an asset
+  // Read an asset into memory, one cached entry per asset id. Assets are immutable
+  // on GitHub, so entries only need eviction when a new release arrives (onRelease).
+  // Caching the promise also coalesces concurrent requests for the same asset.
   async readAsset(asset) {
+    const key = String(asset.id);
+    if (!this.#assetMemos[key]) {
+      this.#assetMemos[key] = this.readAssetFresh(asset).catch((err) => {
+        // never cache failures, e.g. a rate limited backend
+        delete this.#assetMemos[key];
+        throw err;
+      });
+    }
+    return this.#assetMemos[key];
+  }
+
+  // Return the full content of an asset
+  async readAssetFresh(asset) {
     const response = await this.getAssetStream(asset);
     return new Promise((resolve, reject) => {
       let output = Buffer.alloc(0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -299,6 +299,7 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-3.6.0.tgz",
       "integrity": "sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^2.4.4",
         "@octokit/graphql": "^4.5.8",
@@ -3695,6 +3696,7 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
       "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked"
       },
@@ -7968,6 +7970,7 @@
       "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.7.tgz",
       "integrity": "sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^8.0.0",
         "@semantic-release/error": "^2.2.0",


### PR DESCRIPTION
## Summary

`desktop.iarahealth.com` has been returning 500 (`API rate limit exceeded for user ID ...`) since the GitHub account backing `GITHUB_TOKEN` got pinned at its hourly rate limit.

Root cause: every Squirrel.Windows update check hits `/update/channel/:channel/:platform/:version/RELEASES`, and `handleUpdateWin` calls `backend.readAsset(asset)` on every request — a fresh authenticated call to `api.github.com/repos/.../releases/assets/{id}` each time. With clients checking every 15 min regardless of login state, this alone can burn the 5k/h account-wide quota. Once the limit is hit nothing gets memoized, so the pending checks re-burn the quota the moment it resets — which is why it never recovers on its own.

(The releases *list* was already memoized for 1h in `GitHubBackend.releases()`; the macOS update route only uses that list, so it was never the problem.)

## Fix

Memoize `readAsset` in `Backend`, keyed by asset id:

- Assets are immutable on GitHub (replacing one produces a new id), so one entry per asset id covers every channel/platform/version combination with no TTL needed.
- Entries are cleared on `onRelease()` (the existing `/refresh` GitHub webhook path), same invalidation as the releases-list cache.
- The pending promise is what gets cached, so concurrent requests for the same asset coalesce into a single GitHub call.
- Failures are evicted immediately — a rate-limited/failed fetch is never cached.

Net effect: GitHub API usage drops from ~4 calls/hour per Windows client to ~1 paginated releases listing per hour per instance, plus actual downloads.

## Testing

- `npm test` — 23/23 passing
- `npx biome check` clean on the touched file
- Scripted smoke test against a stubbed backend verifying: repeat/concurrent reads produce a single fetch; a failed fetch is not cached and the next call refetches; `onRelease()` invalidates entries.

## Notes

- Cache is in-memory per instance; on Cloud Run it dies with the instance. If instances churn a lot, `min-instances=1` keeps it warm (the hourly releases-list memo benefits too).
- Worth double-checking the release webhook on `iara-desktop` still points at `/refresh` with the right secret, so new releases invalidate promptly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ZRTEjj5thPRBWkRufBn6M


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved asset loading by reusing completed or in-progress reads for the same asset.
  * Reduced duplicate requests when an asset is requested concurrently.
* **Bug Fixes**
  * Failed asset reads are no longer retained in the cache, allowing future attempts to retry successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->